### PR TITLE
Adopt dockable layout to emulate VS Code UI

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -13,9 +13,8 @@
 #include <QMessageBox>
 #include <QFile>
 #include <QTextStream>
-#include <QSplitter>
+#include <QDockWidget>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QDebug>
 #include <QDir>
 #include <QTextBlock>
@@ -77,6 +76,7 @@ void MainWindow::createWidgets()
     treeView->setColumnHidden(1, true);
     treeView->setColumnHidden(2, true);
     treeView->setColumnHidden(3, true);
+    treeView->setHeaderHidden(true);
 
     terminalOutput = new QPlainTextEdit(this);
     terminalOutput->setReadOnly(true); // Make it read-only for historical output
@@ -116,24 +116,24 @@ void MainWindow::createWidgets()
 void MainWindow::setupLayout()
 {
     qDebug() << "setupLayout started.";
-    QSplitter *mainSplitter = new QSplitter(Qt::Horizontal, this);
-    setCentralWidget(mainSplitter);
 
-    QSplitter *editorSplitter = new QSplitter(Qt::Vertical, mainSplitter);
+    setCentralWidget(tabWidget);
 
-    QWidget *terminalWidget = new QWidget(editorSplitter);
+    // Explorer dock
+    QDockWidget *explorerDock = new QDockWidget(tr("Explorer"), this);
+    explorerDock->setWidget(treeView);
+    addDockWidget(Qt::LeftDockWidgetArea, explorerDock);
+
+    // Terminal dock
+    QWidget *terminalWidget = new QWidget(this);
     QVBoxLayout *terminalLayout = new QVBoxLayout(terminalWidget);
     terminalLayout->setContentsMargins(0, 0, 0, 0);
     terminalLayout->addWidget(terminalOutput);
     terminalLayout->addWidget(terminalInput);
 
-    editorSplitter->addWidget(tabWidget);
-    editorSplitter->addWidget(terminalWidget);
-    editorSplitter->setSizes({600, 200});
-
-    mainSplitter->addWidget(treeView);
-    mainSplitter->addWidget(editorSplitter);
-    mainSplitter->setSizes({250, 950});
+    QDockWidget *terminalDock = new QDockWidget(tr("Terminal"), this);
+    terminalDock->setWidget(terminalWidget);
+    addDockWidget(Qt::BottomDockWidgetArea, terminalDock);
 
     // Status bar for indexing progress
     indexingStatusLabel = new QLabel("Ready");

--- a/src/stylesheet.qss
+++ b/src/stylesheet.qss
@@ -69,6 +69,28 @@ QTreeView::item:hover {
     background-color: #333333; /* Subtle hover effect */
 }
 
+/* Dock Widgets (Explorer and Terminal) */
+QDockWidget {
+    background-color: #252526;
+    color: #E0E0E0;
+    border: 1px solid #007ACC;
+}
+
+QDockWidget::title {
+    background-color: #252526;
+    padding: 4px;
+    border-bottom: 1px solid #007ACC;
+}
+
+QDockWidget::close-button, QDockWidget::float-button {
+    border: none;
+    background: transparent;
+}
+
+QDockWidget::close-button:hover, QDockWidget::float-button:hover {
+    background: #007ACC;
+}
+
 /* Tab Widget (Code Editor Tabs) */
 QTabWidget::pane {
     border: 1px solid #007ACC; /* Blue border around the editor area */
@@ -112,19 +134,6 @@ QLineEdit {
     color: #E0E0E0;
     border: 1px solid #007ACC; /* Blue border for input */
     padding: 5px;
-}
-
-/* Splitter Handles */
-QSplitter::handle {
-    background-color: #007ACC; /* Blue splitter handles */
-}
-
-QSplitter::handle:horizontal {
-    width: 2px; /* Thicker handles */
-}
-
-QSplitter::handle:vertical {
-    height: 2px;
 }
 
 /* Status Bar */


### PR DESCRIPTION
## Summary
- Swap splitter-based layout for dock widgets to mimic VS Code's explorer and terminal panels
- Hide file tree header for a cleaner sidebar
- Style dock widgets to match existing dark theme and remove unused splitter styles

## Testing
- `cmake ..` *(fails: could not find Qt6 package)*

------
https://chatgpt.com/codex/tasks/task_e_68953cbb1d188329a7dfe0f4825d2223