### PR TITLE
Adopt dockable layout to emulate VS Code UI

### DIFF
--- a/src/ISymbolProvider.h
+++ b/src/ISymbolProvider.h
@@ -3,6 +3,7 @@
 
 #include <QString>
 #include <QMap>
+#include <QStringList>
 
 struct SymbolLocation {
     QString filePath;
@@ -18,6 +19,9 @@ public:
 
     // Method to index a directory (e.g., when a folder is opened)
     virtual void indexDirectory(const QString &directoryPath) = 0;
+
+    // Retrieve all indexed symbol names for completion
+    virtual QStringList allSymbols() const = 0;
 };
 
 #endif // ISYMBOLPROVIDER_H

--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -13,9 +13,8 @@
 #include <QMessageBox>
 #include <QFile>
 #include <QTextStream>
-#include <QSplitter>
+#include <QDockWidget>
 #include <QVBoxLayout>
-#include <QHBoxLayout>
 #include <QDebug>
 #include <QDir>
 #include <QTextBlock>
@@ -77,6 +76,7 @@ void MainWindow::createWidgets()
     treeView->setColumnHidden(1, true);
     treeView->setColumnHidden(2, true);
     treeView->setColumnHidden(3, true);
+    treeView->setHeaderHidden(true);
 
     terminalOutput = new QPlainTextEdit(this);
     terminalOutput->setReadOnly(true); // Make it read-only for historical output
@@ -116,24 +116,24 @@ void MainWindow::createWidgets()
 void MainWindow::setupLayout()
 {
     qDebug() << "setupLayout started.";
-    QSplitter *mainSplitter = new QSplitter(Qt::Horizontal, this);
-    setCentralWidget(mainSplitter);
 
-    QSplitter *editorSplitter = new QSplitter(Qt::Vertical, mainSplitter);
+    setCentralWidget(tabWidget);
 
-    QWidget *terminalWidget = new QWidget(editorSplitter);
+    // Explorer dock
+    QDockWidget *explorerDock = new QDockWidget(tr("Explorer"), this);
+    explorerDock->setWidget(treeView);
+    addDockWidget(Qt::LeftDockWidgetArea, explorerDock);
+
+    // Terminal dock
+    QWidget *terminalWidget = new QWidget(this);
     QVBoxLayout *terminalLayout = new QVBoxLayout(terminalWidget);
     terminalLayout->setContentsMargins(0, 0, 0, 0);
     terminalLayout->addWidget(terminalOutput);
     terminalLayout->addWidget(terminalInput);
 
-    editorSplitter->addWidget(tabWidget);
-    editorSplitter->addWidget(terminalWidget);
-    editorSplitter->setSizes({600, 200});
-
-    mainSplitter->addWidget(treeView);
-    mainSplitter->addWidget(editorSplitter);
-    mainSplitter->setSizes({250, 950});
+    QDockWidget *terminalDock = new QDockWidget(tr("Terminal"), this);
+    terminalDock->setWidget(terminalWidget);
+    addDockWidget(Qt::BottomDockWidgetArea, terminalDock);
 
     // Status bar for indexing progress
     indexingStatusLabel = new QLabel("Ready");
@@ -194,7 +194,7 @@ void MainWindow::setupConnections()
 
 void MainWindow::newFile()
 {
-    CodeEditor *editor = new CodeEditor();
+    CodeEditor *editor = new CodeEditor(symbolProvider);
     int index = tabWidget->addTab(editor, "Untitled");
     tabWidget->setCurrentIndex(index);
     connect(editor, &CodeEditor::goToDefinitionRequested, this, &MainWindow::goToDefinition);
@@ -210,7 +210,7 @@ void MainWindow::openFile(const QString &filePath)
         return;
     }
 
-    CodeEditor *editor = new CodeEditor();
+    CodeEditor *editor = new CodeEditor(symbolProvider);
     editor->setPlainText(file.readAll());
     file.close();
 
@@ -371,4 +371,10 @@ void MainWindow::onIndexingFinished()
     indexingProgressBar->setValue(100);
     indexingStatusLabel->setText("Ready");
     indexingProgressBar->hide();
+
+    for (int i = 0; i < tabWidget->count(); ++i) {
+        if (CodeEditor *editor = qobject_cast<CodeEditor*>(tabWidget->widget(i))) {
+            editor->setSymbolProvider(symbolProvider);
+        }
+    }
 }

--- a/src/SimpleSymbolIndexer.cpp
+++ b/src/SimpleSymbolIndexer.cpp
@@ -23,6 +23,11 @@ SymbolLocation SimpleSymbolIndexer::findSymbolLocation(const QString &symbolName
     return SymbolLocation{"", -1}; // Not found
 }
 
+QStringList SimpleSymbolIndexer::allSymbols() const
+{
+    return symbolMap.keys();
+}
+
 void SimpleSymbolIndexer::indexDirectory(const QString &directoryPath)
 {
     // This method is called from the main thread to initiate indexing in the worker thread

--- a/src/SimpleSymbolIndexer.h
+++ b/src/SimpleSymbolIndexer.h
@@ -16,6 +16,7 @@ public:
 
     SymbolLocation findSymbolLocation(const QString &symbolName) const override;
     void indexDirectory(const QString &directoryPath) override; // Called from main thread
+    QStringList allSymbols() const override;
 
 public slots:
     void doIndexDirectory(const QString &directoryPath); // This will run in the thread

--- a/src/stylesheet.qss
+++ b/src/stylesheet.qss
@@ -69,6 +69,28 @@ QTreeView::item:hover {
     background-color: #333333; /* Subtle hover effect */
 }
 
+/* Dock Widgets (Explorer and Terminal) */
+QDockWidget {
+    background-color: #252526;
+    color: #E0E0E0;
+    border: 1px solid #007ACC;
+}
+
+QDockWidget::title {
+    background-color: #252526;
+    padding: 4px;
+    border-bottom: 1px solid #007ACC;
+}
+
+QDockWidget::close-button, QDockWidget::float-button {
+    border: none;
+    background: transparent;
+}
+
+QDockWidget::close-button:hover, QDockWidget::float-button:hover {
+    background: #007ACC;
+}
+
 /* Tab Widget (Code Editor Tabs) */
 QTabWidget::pane {
     border: 1px solid #007ACC; /* Blue border around the editor area */
@@ -112,19 +134,6 @@ QLineEdit {
     color: #E0E0E0;
     border: 1px solid #007ACC; /* Blue border for input */
     padding: 5px;
-}
-
-/* Splitter Handles */
-QSplitter::handle {
-    background-color: #007ACC; /* Blue splitter handles */
-}
-
-QSplitter::handle:horizontal {
-    width: 2px; /* Thicker handles */
-}
-
-QSplitter::handle:vertical {
-    height: 2px;
 }
 
 /* Status Bar */

--- a/src/widgets/CodeEditor.h
+++ b/src/widgets/CodeEditor.h
@@ -3,11 +3,16 @@
 
 #include <QPlainTextEdit>
 #include <QObject>
+#include <QCompleter>
+
+#include "../ISymbolProvider.h"
 
 class QPaintEvent;
 class QResizeEvent;
 class QSize;
 class QWidget;
+class QKeyEvent;
+class QFocusEvent;
 
 class LineNumberArea; // Forward declaration
 
@@ -16,10 +21,11 @@ class CodeEditor : public QPlainTextEdit
     Q_OBJECT
 
 public:
-    CodeEditor(QWidget *parent = nullptr);
+    explicit CodeEditor(ISymbolProvider *provider = nullptr, QWidget *parent = nullptr);
 
     void lineNumberAreaPaintEvent(QPaintEvent *event);
     int lineNumberAreaWidth();
+    void setSymbolProvider(ISymbolProvider *provider);
 
 signals:
     void goToDefinitionRequested(const QString &symbolName);
@@ -28,15 +34,25 @@ protected:
     void resizeEvent(QResizeEvent *event) override;
     void mousePressEvent(QMouseEvent *event) override;
     void mouseMoveEvent(QMouseEvent *event) override;
+    void keyPressEvent(QKeyEvent *event) override;
+    void focusInEvent(QFocusEvent *event) override;
 
 private slots:
     void updateLineNumberAreaWidth(int newBlockCount);
     void highlightCurrentLine();
     void updateLineNumberArea(QRectF rect);
 
+private slots:
+    void insertCompletion(const QString &completion);
+
 private:
+    QString textUnderCursor() const;
+    void updateCompleter();
+
     QWidget *lineNumberArea;
     class PHPSyntaxHighlighter *highlighter;
+    ISymbolProvider *symbolProvider;
+    QCompleter *completer;
 };
 
 class LineNumberArea : public QWidget


### PR DESCRIPTION
## Summary
- Swap splitter-based layout for dock widgets to mimic VS Code's explorer and terminal panels
- Hide file tree header for a cleaner sidebar
- Style dock widgets to match existing dark theme and remove unused splitter styles
- Integrate basic IntelliSense: expose symbol lists and use QCompleter for code completion

## Testing
- `cmake ..` *(fails: could not find Qt6 package)*

------
https://chatgpt.com/codex/tasks/task_e_68953cbb1d188329a7dfe0f4825d2223