### PR TITLE
Prevent terminal focus on Shift key press

### DIFF
--- a/src/MainWindow.cpp
+++ b/src/MainWindow.cpp
@@ -295,7 +295,7 @@ void MainWindow::readTerminalOutput()
 
 void MainWindow::keyPressEvent(QKeyEvent *event)
 {
-    if (terminalInput->isVisible() && terminalInput->isEnabled()) {
+    if (terminalInput->isVisible() && terminalInput->isEnabled() && !event->text().isEmpty() && !terminalInput->hasFocus()) {
         terminalInput->setFocus();
     }
     QMainWindow::keyPressEvent(event);


### PR DESCRIPTION
## Summary
- Avoid forcing terminal input focus when pressing modifier keys like Shift.

## Testing
- `cmake ..` *(fails: Could not find a package configuration file provided by "Qt6")*
- `apt-get update` *(fails: The repository 'http://archive.ubuntu.com/ubuntu noble InRelease' is not signed)*

------
https://chatgpt.com/codex/tasks/task_e_689543a4a72483299c0f97d77bb5be4e